### PR TITLE
Make sure element exists before destroying

### DIFF
--- a/addon/components/perfect-scroll/component.js
+++ b/addon/components/perfect-scroll/component.js
@@ -61,7 +61,13 @@ export default Ember.Component.extend({
 
   willDestroyElement() {
     this._super(...arguments);
-    window.Ps.destroy(document.getElementById(get(this, 'eId')));
+    
+    let element = document.getElementById(get(this, 'eId'));
+
+    if (element) {
+      window.Ps.destroy(element);
+    }
+    
     this.unbindEvents();
   },
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import(app.bowerDirectory + '/perfect-scrollbar/js/perfect-scrollbar.js');
-    app.import(app.bowerDirectory + '/perfect-scrollbar/css/perfect-scrollbar.css');
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      app.import(app.bowerDirectory + '/perfect-scrollbar/js/perfect-scrollbar.js');
+      app.import(app.bowerDirectory + '/perfect-scrollbar/css/perfect-scrollbar.css');
+    }
   }
 };


### PR DESCRIPTION
Otherwise you might stumple upon this error:

```
Uncaught TypeError: Cannot read property 'getAttribute' of null
    at getId (perfect-scrollbar.js:1259)
    at Object.exports.get (perfect-scrollbar.js:1283)
    at Object.module.exports [as destroy] (perfect-scrollbar.js:360)
    at Class.willDestroyElement (component.js:51)
```