### PR TITLE
Rename app/components/perfect-scroll/component.js to ../perfect-scroll.js

### DIFF
--- a/app/components/perfect-scroll.js
+++ b/app/components/perfect-scroll.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-perfect-scroll/components/perfect-scroll/component';

--- a/app/components/perfect-scroll/component.js
+++ b/app/components/perfect-scroll/component.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-perfect-scroll/components/perfect-scroll/component';


### PR DESCRIPTION
Fixes component resolution issues caused by pod structure in /app/ folder.

It seems that addons never had full support for pods, and all the documentation available on structuring them (e.g., https://gist.github.com/kristianmandrup/ae3174217f68a6a51ed5) shows them using the /components/,js form inside of /app. As for me, I cannot use the component in my app unless it is structured like this.