### PR TITLE
Ability to specify scrollTop and scrollLeft positions

### DIFF
--- a/addon/components/perfect-scroll/component.js
+++ b/addon/components/perfect-scroll/component.js
@@ -99,6 +99,11 @@ export default Ember.Component.extend({
     });
   },
 
+  didRender() {
+    let el = document.getElementById(get(this, 'eId'));
+    window.Ps.update(el);
+  },
+
   willDestroyElement() {
     this._super(...arguments);
 

--- a/addon/components/perfect-scroll/component.js
+++ b/addon/components/perfect-scroll/component.js
@@ -27,6 +27,18 @@ const psEvents = [
   'ps-x-reach-end'
 ];
 
+var _scrollPositionComputer = {
+  get(key) {
+    return get(this, `_${key}`) || 0;
+  },
+  set(key, value) {
+    set(this, `_${key}`, value);
+    run.schedule('afterRender', () => {
+      get(this, '_scrollElement')[key] = value;
+      window.Ps.update(get(this, '_scrollElement'));
+    });
+  }
+};
 
 export default Ember.Component.extend({
   layout: layout,
@@ -50,33 +62,12 @@ export default Ember.Component.extend({
   theme: 'default',
 
   _scrollTop: 0,
-  scrollTop: computed('_scrollTop', {
-    get() {
-      return get(this, '_scrollTop') || 0;
-    },
-    set(key, value) {
-      set(this, `_${key}`, value);
-      run.schedule('afterRender', () => {
-        get(this, '_scrollElement')[key] = value;
-        window.Ps.update(get(this, '_scrollElement'));
-      });
-    }
-  }),
   _scrollLeft: 0,
-  scrollLeft: computed('_scrollLeft', {
-    get() {
-      return get(this, '_scrollLeft') || 0;
-    },
-    set(key, value) {
-      set(this, `_${key}`, value);
-      run.schedule('afterRender', () => {
-        get(this, '_scrollElement')[key] = value;
-        window.Ps.update(get(this, '_scrollElement'));
-      });
-    }
-  }),
 
-  scrolled(evt){
+  scrollTop:  computed('_scrollTop',  _scrollPositionComputer),
+  scrollLeft: computed('_scrollLeft', _scrollPositionComputer),
+
+  scrolled(evt) {
     this.setProperties({
       "_scrollTop": evt.target.scrollTop,
       "_scrollLeft": evt.target.scrollLeft

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+  scrollTop: 50,
+  scrollLeft: 50,
   actions: {
     yReachEnd() {
       /* eslint-disable no-console */

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,4 +1,4 @@
-{{#perfect-scroll scrollTop=50 ps-y-reach-end=(action 'yReachEnd') ps-scroll-x='scrollX' ps-scroll-y='scrollY'}}
+{{#perfect-scroll scrollTop=scrollTop scrollLeft=scrollLeft ps-y-reach-end=(action 'yReachEnd') ps-scroll-x='scrollX' ps-scroll-y='scrollY'}}
 <div class="content">
 
 </div>

--- a/tests/integration/components/perfect-scroll/component-test.js
+++ b/tests/integration/components/perfect-scroll/component-test.js
@@ -67,3 +67,33 @@ test('it renders with scroll positions, and properties update when scroll is cha
   assert.equal(this.get("scrollTopPosition"), 50);
   assert.equal(this.get("scrollLeftPosition"), 75);
 });
+
+test('it renders with scroll positions, ps-scroll-x and ps-scroll-y events fire', function(assert) {
+  assert.expect(4);
+
+  this.set("scrollTopPosition", 100);
+  this.set("scrollLeftPosition", 125);
+
+  this.set("scrollLeftHandler", function() {
+    assert.ok(true);
+  });
+  this.set("scrollTopHandler", function() {
+    assert.ok(true);
+  });
+
+  this.render(hbs `
+    {{#perfect-scroll
+      scrollTop=scrollTopPosition
+      scrollLeft=scrollLeftPosition
+      ps-scroll-x=(action scrollLeftHandler)
+      ps-scroll-y=(action scrollTopHandler)
+    }}
+      <div style="height:1000px; width:1000px;"></div>
+    {{/perfect-scroll}}
+  `);
+
+  this.set("scrollTopPosition", 0);
+  this.set("scrollLeftPosition", 0);
+  this.set("scrollTopPosition", 100);
+  this.set("scrollLeftPosition", 125);
+});

--- a/tests/integration/components/perfect-scroll/component-test.js
+++ b/tests/integration/components/perfect-scroll/component-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
 
 moduleForComponent('perfect-scroll', 'Integration | Component | perfect scroll', {
   integration: true
@@ -8,4 +9,61 @@ moduleForComponent('perfect-scroll', 'Integration | Component | perfect scroll',
 test('it renders with content "ps"', function(assert) {
   this.render(hbs`{{#perfect-scroll}}ps{{/perfect-scroll}}`);
   assert.equal(this.$().text().trim(), 'ps');
+});
+
+test('it renders with scroll positions', function(assert) {
+  this.render(hbs`{{#perfect-scroll scrollTop=50 scrollLeft=75}}<div style="height:1000px; width:1000px;"></div>{{/perfect-scroll}}`);
+  assert.equal(this.$(".ps-content").scrollTop(), 50);
+  assert.equal(this.$(".ps-content").scrollLeft(), 75);
+});
+
+test('it renders with scroll positions, and updates when properties are changed', function(assert) {
+  this.set("scrollTopPosition", 125);
+  this.set("scrollLeftPosition", 150);
+
+  this.render(hbs`
+    {{#perfect-scroll scrollTop=scrollTopPosition scrollLeft=scrollLeftPosition}}
+      <div style="height:1000px; width:1000px;"></div>
+    {{/perfect-scroll}}
+  `);
+  assert.equal(this.$(".ps-content").scrollTop(), 125);
+  assert.equal(this.$(".ps-content").scrollLeft(), 150);
+
+  this.set("scrollTopPosition", 200);
+  this.set("scrollLeftPosition", 225);
+
+  assert.equal(this.$(".ps-content").scrollTop(), 200);
+  assert.equal(this.$(".ps-content").scrollLeft(), 225);
+});
+
+test('it renders with scroll positions, and properties update when scroll is changed', function(assert) {
+  this.set("scrollTopPosition", 100);
+  this.set("scrollLeftPosition", 125);
+
+  this.render(hbs`
+    {{#perfect-scroll scrollTop=scrollTopPosition scrollLeft=scrollLeftPosition}}
+      <div style="height:1000px; width:1000px;"></div>
+    {{/perfect-scroll}}
+  `);
+  var scrollElement = this.$(".ps-content");
+
+  assert.equal(scrollElement.scrollTop(), 100);
+  assert.equal(scrollElement.scrollLeft(), 125);
+
+  // This must be run after first render, so that perfect-scrollbar can remember the originally rendered position for comparison after we change it.
+  // Must be in a run loop, or else Ember complains.
+  Ember.run(function() {
+    window.Ps.update(scrollElement[0]);
+  });
+
+  scrollElement.scrollTop(50);
+  scrollElement.scrollLeft(75);
+
+  // Update the perfect-scrollbar object, firing events as needed.
+  Ember.run(function() {
+    window.Ps.update(scrollElement[0]);
+  });
+
+  assert.equal(this.get("scrollTopPosition"), 50);
+  assert.equal(this.get("scrollLeftPosition"), 75);
 });


### PR DESCRIPTION
Also, those properties will update as the user scrolls, updating bindings from outside this addon as well.
Additionally, I hooked `didRender` to update perfect-scrollbar's positions and sizing. I think this may also resolve #13 

This needs some polish, but it does seem to work fully. If there's anything you'd like to see changed, feel free to do so, or let me know so I can.

Also, I added tests for the new behavior.